### PR TITLE
Add super admin to spree roles

### DIFF
--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -25,6 +25,8 @@ Spree::User.class_eval do
 
   def ensure_at_least_one_super_admin_exists
     unless super_admin_exists?
+      super_admin_role = Spree::Role.find_or_create_by_name 'super_admin'
+      self.spree_roles << super_admin_role
       self.super_admin = true
     end
   end

--- a/lib/spree/spree_landlord/tenant_bootstrapper.rb
+++ b/lib/spree/spree_landlord/tenant_bootstrapper.rb
@@ -18,7 +18,7 @@ module Spree
       end
 
       def create_tenants_admin_role
-        role = Spree::Role.new(name: 'spree_admin')
+        role = Spree::Role.new(name: 'super_admin')
         role.tenant = first_tenant
         role.save!
         role


### PR DESCRIPTION
I'd like to discuss the presence of super_admin as a field on spree_users as well (shouldn't we just pull super_admin? from has_spree_role?(:super_admin) ? )
