### PR TITLE
reverts super_admin as a spree role.  correctly defaces the admin/user f...

### DIFF
--- a/app/overrides/spree/admin/users/_form/add_super_admin_checkbox.html.erb.deface
+++ b/app/overrides/spree/admin/users/_form/add_super_admin_checkbox.html.erb.deface
@@ -1,4 +1,4 @@
-<!-- insert_after "[data-hook='admin_user_form_roles'] ul" -->
+<!-- insert_bottom "[data-hook='admin_user_form_roles'] ul" -->
 <% if can? :grant_super_admin, f.object %>
   <li>
     <%= f.check_box :super_admin %>


### PR DESCRIPTION
...orm to include the super_admin checkbox

forgot to add this to the commit message: prevents double-admin roles.
