### PR TITLE
Fix abilities for accessible by

### DIFF
--- a/app/models/spree/tenant_ability.rb
+++ b/app/models/spree/tenant_ability.rb
@@ -10,6 +10,15 @@ module Spree
         cannot :grant_super_admin, Spree::User
       end
 
+      # if you are not a super_admin, you can not do
+      # _anything_ to a super_admin Spree::User
+      [:manage, :admin, :edit, :update, :delete].each do |action|
+        if !user.super_admin
+          cannot action, Spree::User, :super_admin => true
+          can action, Spree::User, :id => user.id # allow access to yourself
+        end
+      end
+=begin
       cannot do |action, subject_class, subject|
         if subject_class == Spree::User
           if [:manage, :admin, :edit, :update, :delete].include?(action)
@@ -19,6 +28,8 @@ module Spree
           end
         end
       end
+=end
+
     end
 
     Spree::Ability.register_ability(Spree::TenantAbility)

--- a/app/models/spree/tenant_ability.rb
+++ b/app/models/spree/tenant_ability.rb
@@ -14,22 +14,9 @@ module Spree
       # _anything_ to a super_admin Spree::User
       [:manage, :admin, :edit, :update, :delete].each do |action|
         if !user.super_admin
-          cannot action, Spree::User, :super_admin => true
-          can action, Spree::User, :id => user.id # allow access to yourself
+          cannot action, Spree::User, super_admin: true
         end
       end
-=begin
-      cannot do |action, subject_class, subject|
-        if subject_class == Spree::User
-          if [:manage, :admin, :edit, :update, :delete].include?(action)
-            if subject.super_admin?
-              !user.super_admin
-            end
-          end
-        end
-      end
-=end
-
     end
 
     Spree::Ability.register_ability(Spree::TenantAbility)

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -1,4 +1,6 @@
 Spree::User.class_eval do
+  attr_accessible :super_admin
+
   # ugly hack to remove the uniqueness validator on email
   _validate_callbacks.reject! do |callback|
     callback.raw_filter.kind_of?(ActiveRecord::Validations::UniquenessValidator) &&
@@ -15,7 +17,7 @@ Spree::User.class_eval do
   }
 
   before_save :ensure_at_least_one_super_admin_exists
-  before_save :ensure_super_admin_is_admin
+  after_save :ensure_super_admin_is_admin
 
   protected
 
@@ -25,8 +27,6 @@ Spree::User.class_eval do
 
   def ensure_at_least_one_super_admin_exists
     unless super_admin_exists?
-      super_admin_role = Spree::Role.find_or_create_by_name 'super_admin'
-      self.spree_roles << super_admin_role
       self.super_admin = true
     end
   end

--- a/app/overrides/spree/admin/users/_form/add_super_admin_checkbox.html.erb.deface
+++ b/app/overrides/spree/admin/users/_form/add_super_admin_checkbox.html.erb.deface
@@ -1,4 +1,4 @@
-<!-- insert_after "[data-hook='admin_user_form_roles'] ul" -->
+<!-- insert_bottom "[data-hook='admin_user_form_roles'] ul" -->
 <% if can? :grant_super_admin, f.object %>
   <li>
     <%= f.check_box :super_admin %>


### PR DESCRIPTION
Scott,

I screwed up and accidentally have two commits here.  The 2nd one I'd like for you to take a really good look at if you don't mind.

I left this in your skype window:

i'm actually thinking about reworking it due to a cancan exception:
https://github.com/ryanb/cancan/wiki/Defining-Abilities-with-Blocks

look at the 'fetching records' section

there's an  
    @search = Order.accessible_by(current_ability, :index).ransack(params[:q]) in the admin orders_controller

that chokes b/c the ability was defined using a block...so i'm thinking of reworking using a hash

and i want to confirm the comment i authored above that section is correct:
      # if you are not a super_admin, you can not do
     # _anything_ to a super_admin Spree::User
