### PR TITLE
Seed data is wiped out on every migration

### DIFF
--- a/lib/tasks/spree_landlord.rake
+++ b/lib/tasks/spree_landlord.rake
@@ -100,15 +100,6 @@ namespace :db do
     Spree::SpreeLandlord::TenantMigrator.new.move_unassigned_to_master
   end
 
-  task :migrate => :reset_column_information do
-    # clear tables that are seeded by spree_core
-    Spree::Country.delete_all
-    Spree::State.delete_all
-    Spree::Zone.delete_all
-    Spree::Role.delete_all
-    Spree::ZoneMember.delete_all
-  end
-
   task :reset_column_information do
     ActiveRecord::Base.send(:subclasses).each do |model|
       model.connection.schema_cache.clear!


### PR DESCRIPTION
Every time `rake db:migrate` is run, all of the seed data for the following are wiped out: `Spree::State`, `Spree::Country`, `Spree::Zone`, `Spree::ZoneMember`, and `Spree::Role`.

This code doesn't seem to make sense, unless perhaps it's only run the very first time the landlord code is run. If that's the case, then it should probably be in a single migration file, not in the migrate task. 
