### PR TITLE
Made tenant before_filters use prepend_before_filter

### DIFF
--- a/lib/spree/spree_landlord/tenant_helpers.rb
+++ b/lib/spree/spree_landlord/tenant_helpers.rb
@@ -4,8 +4,8 @@ module Spree
       extend ActiveSupport::Concern
 
       included do
-        prepend_before_filter :set_current_tenant
         prepend_before_filter :add_tenant_view_path
+        prepend_before_filter :set_current_tenant
       end
 
       def set_current_tenant

--- a/lib/spree/spree_landlord/tenant_helpers.rb
+++ b/lib/spree/spree_landlord/tenant_helpers.rb
@@ -4,8 +4,8 @@ module Spree
       extend ActiveSupport::Concern
 
       included do
-        before_filter :set_current_tenant
-        before_filter :add_tenant_view_path
+        prepend_before_filter :set_current_tenant
+        prepend_before_filter :add_tenant_view_path
       end
 
       def set_current_tenant


### PR DESCRIPTION
Made tenant `before_filters` use `prepend_before_filter` so it switches tenants before any other `before_filters` in Spree core.

This caused several issues. For example, if you opened two different browser windows and had shopping carts open across multiple tenants, then the orders would clobber each other and mess up the session in the other window.
