### PR TITLE
Changed tenant_finder to raise TenantNotFound when unknown subdomain on master

### DIFF
--- a/lib/spree/spree_landlord/tenant_finder.rb
+++ b/lib/spree/spree_landlord/tenant_finder.rb
@@ -12,22 +12,41 @@ module Spree
           subdomain_tenant = Spree::Tenant.find_by_shortname(shortname.downcase)
         end
 
-        if subdomain_tenant.present? && domain_tenant.present? && Spree::Tenant.master == domain_tenant
-          subdomain_tenant
-        elsif domain_tenant.present?
-          domain_tenant
-        elsif subdomain_tenant.present?
-          subdomain_tenant
-        elsif request.domain == 'localhost' || request.domain.nil?
-          Spree::Tenant.master
-        else
-          full_domain = request.domain
-          if shortname.present?
-            full_domain = shortname + '.' + full_domain
+        if is_master_tenant?(domain_tenant)
+          if subdomain_tenant.present?
+            return subdomain_tenant
+          else
+            raise_tenant_not_found_error(request)
           end
-          raise TenantNotFound, "No tenant could be found for '#{full_domain}'"
+        else #not master tenant
+          if domain_tenant.present? 
+            return domain_tenant
+          elsif subdomain_tenant.present?
+            return subdomain_tenant
+          elsif request.domain == 'localhost' || request.domain.nil?
+            return Spree::Tenant.master
+          end
         end
+
+        raise_tenant_not_found_error(request)
       end
+
+      private 
+
+      def is_master_tenant?(tenant)
+        Spree::Tenant.master == tenant
+      end
+
+      def raise_tenant_not_found_error(request)
+        full_domain = request.domain
+        shortname = request.subdomains.first
+        if shortname.present?
+          full_domain = shortname + '.' + full_domain
+        end
+        raise TenantNotFound, "No tenant could be found for '#{full_domain}'"
+      end
+
     end
   end
 end
+

--- a/spec/lib/spree/spree_landlord/tenant_finder_spec.rb
+++ b/spec/lib/spree/spree_landlord/tenant_finder_spec.rb
@@ -37,8 +37,10 @@ describe Spree::SpreeLandlord::TenantFinder do
     end
 
     describe 'subdomains on master domain' do
-      it 'permits use of unknown subdomains' do
-        finder.find_target_tenant(request('http://www.master.com')).should == master
+      it 'does not permit use of unknown subdomains' do
+        expect {
+          finder.find_target_tenant(request('http://blahblah.master.com'))
+        }.to raise_error(Spree::SpreeLandlord::TenantNotFound, "No tenant could be found for 'blahblah.master.com'")
       end
 
       it 'honors known subdomain' do


### PR DESCRIPTION
It doesn't really make sense to have some unknown subdomain on the master domain just render the contents master tenant while leaving the unknown subdomain in the url bar of the browser.

For example,  imagine you have a master tenant on `www.masterdomain.com` and a subdomain tenant called `foo.masterdomain.com`. 

With the behavior before this pull request, if someone accidentally goes to `fop.masterdomain.com` they would see `fop.masterdomain.com` in the browser, but they would see the contents of `www.masterdomain.com`. 

With this pull request, if someone goes to `fop.masterdomain.com`, landlord will raise an error and the application controller for the app can decide what to do: show a 404, redirect to www, lookup from a commonly mispelled subdomain table, etc.
